### PR TITLE
docs/daily-til/2025.08.01

### DIFF
--- a/daily/2025.08.01.13.47_why_acm_certificate_management_patterns_comparison.md
+++ b/daily/2025.08.01.13.47_why_acm_certificate_management_patterns_comparison.md
@@ -1,0 +1,136 @@
+# なぜTerraformでACM証明書を管理する際にパターンを比較するのか
+
+## What's this file?
+> [!NOTE]
+> **Why**
+> 
+> **なぜ**TerraformでACM証明書を管理する際に複数のパターンを比較して選択する必要があるのか
+
+## Conclusion (忙しいとき向け)
+> [!IMPORTANT]
+> **Why** : **なぜ**TerraformでACM証明書を管理する際に複数のパターンを比較して選択する必要があるのか
+> 
+> **Answer** : 新規作成パターンはInfrastructure as Codeの完全性を保つが、DNS検証に時間がかかる。既存参照パターンは高速で安全だが、管理が分散する。プロジェクトの要件に応じた選択が必要。
+
+## 目次
+<details>
+<summary>目次を開く</summary>
+
+- [パターン1: Terraformで新規証明書を作成・管理](#パターン1-terraformで新規証明書を作成管理)
+- [パターン2: 既存の証明書を参照](#パターン2-既存の証明書を参照)
+- [使い分けの指針](#使い分けの指針)
+- [ハイブリッドアプローチ](#ハイブリッドアプローチ)
+
+</details>
+
+## パターン1: Terraformで新規証明書を作成・管理
+
+### 実装例
+```hcl
+resource "aws_acm_certificate" "cloudfront" {
+  provider = aws.virginia
+  count    = var.domain_name != "" ? 1 : 0
+  
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+  
+  tags = {
+    Name        = "${var.project_name}-${var.environment}-cloudfront-cert"
+    Environment = var.environment
+  }
+}
+```
+
+### 特徴
+- **リソースタイプ**: `resource`を使用
+- **証明書のライフサイクル**: Terraformが完全に管理
+- **DNS検証**: Terraform実行時に行われる
+- **条件付き作成**: `count`パラメータで制御可能
+
+### メリット
+1. Infrastructure as Code の原則に完全に準拠
+2. 証明書の作成から削除まで一元管理
+3. タグやその他の設定を柔軟に管理可能
+4. terraform destroyで証明書も削除される
+
+### デメリット
+1. DNS検証に時間がかかる（最大30分程度）
+2. terraform applyがDNS検証完了まで待機
+3. 証明書の更新時にダウンタイムの可能性
+4. 手動でのDNSレコード設定が必要な場合がある
+
+## パターン2: 既存の証明書を参照
+
+### 実装例
+```hcl
+data "aws_acm_certificate" "project_virginia" {
+  domain   = terraform.workspace != "prod" ? "project-${terraform.workspace}.jp" : "project.jp"
+  provider = aws.virginia
+}
+```
+
+### 特徴
+- **リソースタイプ**: `data`を使用
+- **証明書のライフサイクル**: Terraform外で管理
+- **DNS検証**: 事前に完了している必要がある
+- **条件付き参照**: ワークスペースベースの動的参照
+
+### メリット
+1. terraform applyが高速（検証待ちなし）
+2. 証明書の管理を分離できる
+3. 既存の証明書管理プロセスと統合しやすい
+4. 証明書の誤削除リスクが低い
+
+### デメリット
+1. 証明書が存在しない場合はエラー
+2. 証明書の設定変更はTerraform外で行う必要
+3. Infrastructure as Codeの完全性が損なわれる
+4. 証明書の管理プロセスが分散する
+
+## 使い分けの指針
+
+### パターン1（新規作成）を選ぶべき場合
+- 開発環境や検証環境
+- 証明書のライフサイクルをTerraformで完全管理したい
+- CI/CDパイプラインで自動化したい
+- DNS検証の待機時間が許容できる
+
+### パターン2（既存参照）を選ぶべき場合
+- 本番環境
+- 証明書の管理を専門チームが行う
+- terraform applyの実行時間を短縮したい
+- 既に証明書管理の仕組みが確立されている
+
+## ハイブリッドアプローチ
+
+環境によって使い分けることも可能です：
+
+```hcl
+# 開発環境では新規作成、本番環境では既存参照
+resource "aws_acm_certificate" "cert" {
+  count = terraform.workspace != "prod" ? 1 : 0
+  # ...
+}
+
+data "aws_acm_certificate" "cert" {
+  count = terraform.workspace == "prod" ? 1 : 0
+  # ...
+}
+
+# 使用時は条件分岐
+locals {
+  certificate_arn = terraform.workspace != "prod" ? 
+    aws_acm_certificate.cert[0].arn : 
+    data.aws_acm_certificate.cert[0].arn
+}
+```
+
+## 関連
+- [AWS ACM証明書のTerraform設定ガイド](./2025.08.01.14.31_how_aws_acm_certificate_terraform_configuration_guide.md)
+- [AWS ACM証明書のProvider設定詳解](./2025.08.01.14.38_how_aws_acm_certificate_provider_configuration_details.md)
+- [AWS ACM証明書のcount設定詳解](./2025.08.01.14.43_how_aws_acm_certificate_count_configuration_details.md)
+- [AWS Certificate Managerベストプラクティス](https://docs.aws.amazon.com/acm/latest/userguide/acm-best-practices.html)

--- a/daily/2025.08.01.14.31_how_aws_acm_certificate_terraform_configuration_guide.md
+++ b/daily/2025.08.01.14.31_how_aws_acm_certificate_terraform_configuration_guide.md
@@ -1,0 +1,252 @@
+# AWS ACM証明書のTerraform設定ガイド
+
+## What's this file?
+> [!NOTE]
+> **How**
+> 
+> どのようにTerraformを使用してACM証明書を作成・管理するかについて記載しています。
+
+## Conclusion (忙しいとき向け)
+> [!IMPORTANT]
+> **How** : **どのように**Terraformを使用してACM証明書を作成・管理するか
+> 
+> **Answer** : `aws_acm_certificate`リソースを使用し、`validation_method`に`DNS`を指定してDNS検証を行い、`aws_acm_certificate_validation`リソースで検証を完了させる
+
+## 目次
+
+<details>
+<summary>目次を開く</summary>
+
+- [基本的な使用方法](#基本的な使用方法)
+- [主要な引数](#主要な引数)
+- [検証方法](#検証方法)
+- [エクスポートされる属性](#エクスポートされる属性)
+- [重要な注意事項](#重要な注意事項)
+- [実践的な例](#実践的な例)
+- [トラブルシューティング](#トラブルシューティング)
+- [ベストプラクティス](#ベストプラクティス)
+
+</details>
+
+## 基本的な使用方法
+
+### リソースの定義
+```hcl
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "example.com"
+  validation_method = "DNS"
+
+  tags = {
+    Environment = "test"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+## 主要な引数
+
+### 必須引数
+- `domain_name` - (必須) 証明書でカバーするドメイン名
+
+### オプション引数
+- `validation_method` - (オプション) 証明書の検証方法。`DNS` または `EMAIL`。デフォルトは `EMAIL`
+- `subject_alternative_names` - (オプション) 証明書に含める追加のドメイン名のリスト
+- `tags` - (オプション) リソースに付与するタグのマップ
+- `certificate_authority_arn` - (オプション) プライベート証明書の場合のCA ARN
+
+## 検証方法
+
+### DNS検証
+DNS検証は推奨される方法で、自動更新が可能です。
+
+```hcl
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "example.com"
+  validation_method = "DNS"
+
+  subject_alternative_names = [
+    "www.example.com",
+    "api.example.com"
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.main.zone_id
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+```
+
+### Email検証
+Email検証は手動での承認が必要です。
+
+```hcl
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "example.com"
+  validation_method = "EMAIL"
+
+  validation_options {
+    domain_name       = "example.com"
+    validation_domain = "example.com"
+  }
+}
+```
+
+## エクスポートされる属性
+
+- `id` - 証明書のARN
+- `arn` - 証明書のARN
+- `domain_name` - 証明書のドメイン名
+- `domain_validation_options` - DNS検証に必要な情報を含むセット
+- `status` - 証明書のステータス
+- `type` - 証明書のタイプ
+
+## 重要な注意事項
+
+### 1. リージョンの考慮事項
+CloudFrontで使用する証明書は、`us-east-1`リージョンで作成する必要があります。
+
+```hcl
+provider "aws" {
+  alias  = "virginia"
+  region = "us-east-1"
+}
+
+resource "aws_acm_certificate" "cloudfront_cert" {
+  provider          = aws.virginia
+  domain_name       = "example.com"
+  validation_method = "DNS"
+}
+```
+
+### 2. ライフサイクル管理
+証明書を置き換える際のダウンタイムを避けるため、`create_before_destroy`を使用することを推奨します。
+
+```hcl
+lifecycle {
+  create_before_destroy = true
+}
+```
+
+### 3. ワイルドカード証明書
+ワイルドカード証明書もサポートされています。
+
+```hcl
+resource "aws_acm_certificate" "wildcard" {
+  domain_name       = "*.example.com"
+  validation_method = "DNS"
+  
+  subject_alternative_names = [
+    "example.com"
+  ]
+}
+```
+
+## 実践的な例
+
+### 1. 本番環境向けの設定
+```hcl
+resource "aws_acm_certificate" "production" {
+  domain_name = "example.com"
+  
+  subject_alternative_names = [
+    "*.example.com",
+    "api.example.com",
+    "admin.example.com"
+  ]
+  
+  validation_method = "DNS"
+  
+  tags = {
+    Name        = "example-production-cert"
+    Environment = "production"
+    ManagedBy   = "terraform"
+  }
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+### 2. 複数環境での利用
+```hcl
+resource "aws_acm_certificate" "main" {
+  domain_name = terraform.workspace == "production" ? 
+    "example.com" : 
+    "${terraform.workspace}.example.com"
+  
+  validation_method = "DNS"
+  
+  tags = {
+    Name        = "example-${terraform.workspace}-cert"
+    Environment = terraform.workspace
+  }
+  
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+```
+
+### 3. 既存証明書の参照
+新規作成ではなく、既存の証明書を参照する場合：
+
+```hcl
+data "aws_acm_certificate" "existing" {
+  domain   = "example.com"
+  statuses = ["ISSUED"]
+  
+  # 最新の証明書を取得
+  most_recent = true
+}
+```
+
+## トラブルシューティング
+
+### 1. 検証タイムアウト
+DNS検証は通常数分で完了しますが、最大30分かかる場合があります。
+
+### 2. 証明書の削除エラー
+使用中の証明書は削除できません。先に関連リソース（CloudFront、ALBなど）から証明書の参照を削除してください。
+
+### 3. リージョンエラー
+CloudFrontで「証明書が見つからない」エラーが発生する場合は、証明書が`us-east-1`リージョンに作成されているか確認してください。
+
+## ベストプラクティス
+
+1. **自動検証の活用**: 可能な限りDNS検証を使用し、自動更新を有効にする
+2. **タグの活用**: 環境、プロジェクト、管理者などの情報をタグで管理
+3. **ライフサイクルの設定**: `create_before_destroy`で無停止更新を実現
+4. **監視の設定**: 証明書の有効期限をCloudWatchで監視
+5. **ドキュメント化**: 証明書の用途、関連サービスをコメントで記載
+
+## 関連
+- [AWS ACM Certificate Provider設定](./2025.08.01.14.38_how_aws_acm_certificate_provider_configuration_details.md)
+- [AWS ACM Certificate Count設定](./2025.08.01.14.43_how_aws_acm_certificate_count_configuration_details.md)
+- [ACM証明書管理パターン比較](./2025.08.01.13.47_why_acm_certificate_management_patterns_comparison.md)
+- [AWS ACM公式ドキュメント](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)
+- [Terraform AWS Provider ACM Certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate)

--- a/daily/2025.08.01.14.38_how_aws_acm_certificate_provider_configuration_details.md
+++ b/daily/2025.08.01.14.38_how_aws_acm_certificate_provider_configuration_details.md
@@ -1,0 +1,272 @@
+# AWS ACM証明書のProvider設定詳解
+
+## What's this file?
+> [!NOTE]
+> **How**
+> 
+> どのようにAWS ACM証明書のProvider設定を行うかについて記載しています。
+
+## Conclusion (忙しいとき向け)
+> [!IMPORTANT]
+> **How** : どのようにAWS ACM証明書のProvider設定を行うか
+> 
+> **Answer** : CloudFront用の証明書は`provider = aws.virginia`を指定してus-east-1リージョンに作成し、リージョナルサービス用はサービスと同じリージョンのProviderを使用する
+
+## 目次
+
+<details>
+<summary>目次を開く</summary>
+
+- [Provider設定の基本](#provider設定の基本)
+- [なぜProvider設定が重要なのか](#なぜprovider設定が重要なのか)
+- [実践的なProvider設定パターン](#実践的なprovider設定パターン)
+- [Provider設定のベストプラクティス](#provider設定のベストプラクティス)
+- [トラブルシューティング](#トラブルシューティング)
+- [実装チェックリスト](#実装チェックリスト)
+
+</details>
+
+## Provider設定の基本
+
+### 設定項目の詳細
+
+| 項目名 | 必須 | 型 | 説明 |
+|--------|------|-----|------|
+| `provider` | × | string | 使用するAWSプロバイダーのエイリアス名。デフォルトプロバイダーを使用する場合は省略可能 |
+
+### 基本的な使用例
+
+```hcl
+# デフォルトプロバイダーを使用する場合（provider指定なし）
+resource "aws_acm_certificate" "cert" {
+  domain_name       = "example.com"
+  validation_method = "DNS"
+}
+
+# 特定のプロバイダーを明示的に指定する場合
+resource "aws_acm_certificate" "cert" {
+  provider          = aws.virginia
+  domain_name       = "example.com"
+  validation_method = "DNS"
+}
+```
+
+## なぜProvider設定が重要なのか
+
+### 1. CloudFrontでの使用
+
+CloudFrontは**グローバルサービス**であり、ACM証明書は必ず**us-east-1（バージニア北部）リージョン**に作成する必要があります。
+
+```hcl
+# プロバイダーの定義
+provider "aws" {
+  region = "ap-northeast-1"  # デフォルトリージョン（東京）
+}
+
+provider "aws" {
+  alias  = "virginia"
+  region = "us-east-1"  # CloudFront用のリージョン
+}
+
+# CloudFront用の証明書（us-east-1で作成）
+resource "aws_acm_certificate" "cloudfront_cert" {
+  provider          = aws.virginia  # 重要：us-east-1プロバイダーを指定
+  domain_name       = "example.com"
+  validation_method = "DNS"
+  
+  tags = {
+    Name = "cloudfront-certificate"
+    Use  = "CloudFront"
+  }
+}
+```
+
+### 2. リージョナルサービスでの使用
+
+ALB、API Gatewayなどのリージョナルサービスでは、**サービスと同じリージョン**に証明書を作成する必要があります。
+
+```hcl
+# ALB用の証明書（東京リージョン）
+resource "aws_acm_certificate" "alb_cert" {
+  # providerを指定しない場合、デフォルトプロバイダー（東京）が使用される
+  domain_name       = "api.example.com"
+  validation_method = "DNS"
+  
+  tags = {
+    Name = "alb-certificate"
+    Use  = "ALB"
+  }
+}
+```
+
+## 実践的なProvider設定パターン
+
+### パターン1: マルチリージョン構成
+
+```hcl
+# プロバイダー定義
+provider "aws" {
+  region = "ap-northeast-1"
+  alias  = "tokyo"
+}
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "virginia"
+}
+
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "ireland"
+}
+
+# 各リージョンの証明書
+resource "aws_acm_certificate" "tokyo_cert" {
+  provider          = aws.tokyo
+  domain_name       = "tokyo.example.com"
+  validation_method = "DNS"
+}
+
+resource "aws_acm_certificate" "virginia_cert" {
+  provider          = aws.virginia
+  domain_name       = "global.example.com"
+  validation_method = "DNS"
+}
+
+resource "aws_acm_certificate" "ireland_cert" {
+  provider          = aws.ireland
+  domain_name       = "eu.example.com"
+  validation_method = "DNS"
+}
+```
+
+### パターン2: 環境別Provider設定
+
+```hcl
+# 環境に応じたプロバイダー設定
+provider "aws" {
+  region = var.aws_region
+  
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_id}:role/TerraformRole"
+  }
+}
+
+provider "aws" {
+  alias  = "virginia"
+  region = "us-east-1"
+  
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_id}:role/TerraformRole"
+  }
+}
+```
+
+### パターン3: モジュール内でのProvider継承
+
+```hcl
+# ルートモジュール
+module "certificates" {
+  source = "./modules/certificates"
+  
+  providers = {
+    aws          = aws
+    aws.virginia = aws.virginia
+  }
+}
+
+# モジュール内（modules/certificates/main.tf）
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.virginia]
+    }
+  }
+}
+
+resource "aws_acm_certificate" "regional" {
+  # デフォルトプロバイダーを使用
+  domain_name = var.regional_domain
+  validation_method = "DNS"
+}
+
+resource "aws_acm_certificate" "global" {
+  provider    = aws.virginia  # エイリアスプロバイダーを使用
+  domain_name = var.global_domain
+  validation_method = "DNS"
+}
+```
+
+## Provider設定のベストプラクティス
+
+### 1. 明示的な指定
+
+```hcl
+# 推奨：用途が明確な場合は常にproviderを明示的に指定
+resource "aws_acm_certificate" "cloudfront_cert" {
+  provider = aws.virginia  # CloudFront用であることが明確
+  # ...
+}
+```
+
+### 2. エイリアスの命名規則
+
+| 用途 | 推奨エイリアス名 | 例 |
+|------|-----------------|-----|
+| リージョン指定 | リージョンの通称 | `aws.virginia`, `aws.tokyo` |
+| 環境指定 | 環境名 | `aws.production`, `aws.staging` |
+| アカウント指定 | アカウントの用途 | `aws.security`, `aws.logging` |
+
+### 3. 設定の一元管理
+
+```hcl
+# providers.tf として別ファイルで管理
+provider "aws" {
+  region = local.default_region
+}
+
+provider "aws" {
+  alias  = "virginia"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "oregon"
+  region = "us-west-2"
+}
+```
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+| 問題 | 原因 | 解決方法 |
+|------|------|----------|
+| CloudFrontで証明書が見つからない | 証明書がus-east-1以外で作成されている | `provider = aws.virginia`を指定して再作成 |
+| `Provider configuration not present` | エイリアスプロバイダーが定義されていない | 必要なプロバイダー定義を追加 |
+| 異なるリージョンの証明書が作成される | デフォルトプロバイダーのリージョンが意図と異なる | 明示的にproviderを指定 |
+
+### デバッグ方法
+
+```hcl
+# 証明書がどのリージョンに作成されたか確認
+output "certificate_region" {
+  value = regex("arn:aws:acm:([^:]+):", aws_acm_certificate.cert.arn)[0]
+}
+```
+
+## 実装チェックリスト
+
+- [ ] CloudFront用証明書には`provider = aws.virginia`を指定している
+- [ ] リージョナルサービス用証明書は適切なリージョンで作成している
+- [ ] プロバイダーエイリアスに一貫性のある命名規則を使用している
+- [ ] モジュール使用時は`configuration_aliases`を定義している
+- [ ] 不要なプロバイダー定義を削除している
+
+## 関連
+- [AWS ACM証明書のTerraform設定ガイド](./2025.08.01.14.31_how_aws_acm_certificate_terraform_configuration_guide.md)
+- [AWS ACM Certificate Count設定](./2025.08.01.14.43_how_aws_acm_certificate_count_configuration_details.md)
+- [ACM証明書管理パターン比較](./2025.08.01.13.47_why_acm_certificate_management_patterns_comparison.md)
+- [Terraform AWS Providerドキュメント](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#providers)

--- a/daily/2025.08.01.14.43_how_aws_acm_certificate_count_configuration_details.md
+++ b/daily/2025.08.01.14.43_how_aws_acm_certificate_count_configuration_details.md
@@ -1,0 +1,391 @@
+# AWS ACM証明書のcount設定詳解
+
+## What's this file?
+> [!NOTE]
+> **How**
+> 
+> どのようにTerraformの`count`メタ引数を使用してAWS ACM証明書を管理するかについて記載しています。
+
+## Conclusion (忙しいとき向け)
+> [!IMPORTANT]
+> **How** : どのようにTerraformの`count`メタ引数を使用してAWS ACM証明書を管理するか
+> 
+> **Answer** : `count = var.condition ? 1 : 0`で条件付き作成を実現し、`count = length(var.list)`で複数証明書の一括作成を行い、`aws_acm_certificate.cert[0].arn`でリソースを参照する
+
+## 目次
+
+<details>
+<summary>目次を開く</summary>
+
+- [count設定の基本](#count設定の基本)
+- [countの主な使用パターン](#countの主な使用パターン)
+- [countとインデックスの活用](#countとインデックスの活用)
+- [参照方法](#参照方法)
+- [実践的な使用例](#実践的な使用例)
+- [countとfor_eachの比較](#countとfor_eachの比較)
+- [ベストプラクティス](#ベストプラクティス)
+- [トラブルシューティング](#トラブルシューティング)
+
+</details>
+
+## count設定の基本
+
+### 設定項目の詳細
+
+| 項目名 | 必須 | 型 | デフォルト値 | 説明 |
+|--------|------|-----|-------------|------|
+| `count` | × | number | 1 | 作成するリソースインスタンスの数。0を指定するとリソースは作成されない |
+
+### 基本的な使用例
+
+```hcl
+# 条件付き作成（ドメイン名が設定されている場合のみ作成）
+resource "aws_acm_certificate" "cert" {
+  count = var.domain_name != "" ? 1 : 0
+  
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+}
+
+# 複数証明書の作成
+resource "aws_acm_certificate" "multi_cert" {
+  count = length(var.domain_list)
+  
+  domain_name       = var.domain_list[count.index]
+  validation_method = "DNS"
+}
+```
+
+## countの主な使用パターン
+
+### 1. 条件付きリソース作成
+
+最も一般的な使用方法は、特定の条件に基づいて証明書を作成するかどうかを制御することです。
+
+```hcl
+# 例1: 環境による条件分岐
+resource "aws_acm_certificate" "production_cert" {
+  count = terraform.workspace == "production" ? 1 : 0
+  
+  domain_name       = "example.com"
+  validation_method = "DNS"
+  
+  tags = {
+    Name = "production-certificate"
+  }
+}
+
+# 例2: 機能フラグによる制御
+variable "enable_ssl" {
+  description = "SSL/TLS証明書を有効にするか"
+  type        = bool
+  default     = false
+}
+
+resource "aws_acm_certificate" "optional_cert" {
+  count = var.enable_ssl ? 1 : 0
+  
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+}
+
+# 例3: 複数条件の組み合わせ
+resource "aws_acm_certificate" "conditional_cert" {
+  count = var.enable_ssl && var.domain_name != "" ? 1 : 0
+  
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+}
+```
+
+### 2. 複数証明書の一括作成
+
+複数のドメインに対して個別の証明書を作成する場合に使用します。
+
+```hcl
+variable "domains" {
+  description = "証明書を作成するドメインのリスト"
+  type        = list(string)
+  default     = ["api.example.com", "app.example.com", "admin.example.com"]
+}
+
+resource "aws_acm_certificate" "multi_domain_certs" {
+  count = length(var.domains)
+  
+  domain_name       = var.domains[count.index]
+  validation_method = "DNS"
+  
+  tags = {
+    Name   = "${var.domains[count.index]}-certificate"
+    Index  = count.index
+    Domain = var.domains[count.index]
+  }
+}
+```
+
+### 3. マップを使用した高度な管理
+
+```hcl
+variable "certificate_configs" {
+  description = "証明書設定のマップ"
+  type = map(object({
+    domain_name = string
+    san_domains = list(string)
+    environment = string
+  }))
+  default = {
+    main = {
+      domain_name = "example.com"
+      san_domains = ["*.example.com", "www.example.com"]
+      environment = "production"
+    }
+    api = {
+      domain_name = "api.example.com"
+      san_domains = ["api-v1.example.com", "api-v2.example.com"]
+      environment = "production"
+    }
+  }
+}
+
+resource "aws_acm_certificate" "mapped_certs" {
+  for_each = var.certificate_configs  # countの代わりにfor_eachを使用
+  
+  domain_name               = each.value.domain_name
+  subject_alternative_names = each.value.san_domains
+  validation_method         = "DNS"
+  
+  tags = {
+    Name        = "${each.key}-certificate"
+    Environment = each.value.environment
+  }
+}
+```
+
+## countとインデックスの活用
+
+### count.indexの使用方法
+
+| 属性 | 説明 | 使用例 |
+|------|------|--------|
+| `count.index` | 現在のインスタンスのインデックス（0から開始） | `var.domains[count.index]` |
+
+```hcl
+# インデックスを使った命名
+resource "aws_acm_certificate" "indexed_certs" {
+  count = 3
+  
+  domain_name = "app${count.index + 1}.example.com"  # app1, app2, app3
+  validation_method = "DNS"
+  
+  tags = {
+    Name  = "certificate-${count.index + 1}"
+    Index = count.index
+  }
+}
+```
+
+## 参照方法
+
+### count使用時のリソース参照
+
+```hcl
+# 単一リソース（count = 0 or 1）の参照
+resource "aws_cloudfront_distribution" "cdn" {
+  # countが1の場合
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.cert[0].arn
+  }
+}
+
+# 条件付き参照
+locals {
+  certificate_arn = length(aws_acm_certificate.cert) > 0 ? aws_acm_certificate.cert[0].arn : null
+}
+
+# 複数リソースの参照
+output "all_certificate_arns" {
+  value = aws_acm_certificate.multi_cert[*].arn
+}
+
+# 特定インデックスの参照
+output "first_certificate_domain" {
+  value = length(aws_acm_certificate.multi_cert) > 0 ? aws_acm_certificate.multi_cert[0].domain_name : null
+}
+```
+
+## 実践的な使用例
+
+### 1. 環境別証明書管理
+
+```hcl
+locals {
+  environments = ["dev", "stg", "prod"]
+  base_domain  = "example.com"
+}
+
+resource "aws_acm_certificate" "env_certs" {
+  count    = length(local.environments)
+  provider = aws.virginia  # CloudFront用
+  
+  domain_name = local.environments[count.index] == "prod" ? 
+    local.base_domain : 
+    "${local.environments[count.index]}.${local.base_domain}"
+  
+  subject_alternative_names = local.environments[count.index] == "prod" ? 
+    ["*.${local.base_domain}"] : 
+    ["*.${local.environments[count.index]}.${local.base_domain}"]
+  
+  validation_method = "DNS"
+  
+  tags = {
+    Name        = "${local.environments[count.index]}-certificate"
+    Environment = local.environments[count.index]
+  }
+}
+```
+
+### 2. オプショナルなワイルドカード証明書
+
+```hcl
+variable "enable_wildcard" {
+  description = "ワイルドカード証明書を作成するか"
+  type        = bool
+  default     = false
+}
+
+variable "primary_domain" {
+  description = "プライマリドメイン"
+  type        = string
+}
+
+# プライマリ証明書（常に作成）
+resource "aws_acm_certificate" "primary" {
+  domain_name       = var.primary_domain
+  validation_method = "DNS"
+  
+  tags = {
+    Name = "primary-certificate"
+    Type = "primary"
+  }
+}
+
+# ワイルドカード証明書（オプション）
+resource "aws_acm_certificate" "wildcard" {
+  count = var.enable_wildcard ? 1 : 0
+  
+  domain_name = "*.${var.primary_domain}"
+  subject_alternative_names = [var.primary_domain]
+  validation_method = "DNS"
+  
+  tags = {
+    Name = "wildcard-certificate"
+    Type = "wildcard"
+  }
+}
+```
+
+### 3. 動的なSAN証明書作成
+
+```hcl
+variable "main_domain" {
+  type = string
+}
+
+variable "subdomains" {
+  description = "作成するサブドメインのリスト"
+  type        = list(string)
+  default     = []
+}
+
+resource "aws_acm_certificate" "dynamic_san" {
+  count = length(var.subdomains) > 0 ? 1 : 0
+  
+  domain_name = var.main_domain
+  subject_alternative_names = concat(
+    ["*.${var.main_domain}"],
+    [for subdomain in var.subdomains : "${subdomain}.${var.main_domain}"]
+  )
+  validation_method = "DNS"
+  
+  tags = {
+    Name         = "${var.main_domain}-certificate"
+    SubdomainCount = length(var.subdomains)
+  }
+}
+```
+
+## countとfor_eachの比較
+
+| 特徴 | count | for_each |
+|------|-------|----------|
+| 使用場面 | インデックスベースの作成、条件付き作成 | キーベースの作成、より複雑な構造 |
+| 参照方法 | インデックス（`[0]`, `[1]`） | キー（`["main"]`, `["api"]`） |
+| 削除時の影響 | インデックスがずれる可能性 | キーベースなので影響なし |
+| 条件付き作成 | `count = condition ? 1 : 0` | 条件付きマップの作成が必要 |
+
+## ベストプラクティス
+
+### 1. 明示的な条件設定
+
+```hcl
+# 良い例：条件が明確
+count = var.create_certificate ? 1 : 0
+
+# 避けるべき例：暗黙的な型変換
+count = var.create_certificate  # boolをnumberに暗黙変換
+```
+
+### 2. null値の適切な処理
+
+```hcl
+# 証明書が作成されない場合を考慮
+output "certificate_arn" {
+  value = try(aws_acm_certificate.cert[0].arn, null)
+}
+```
+
+### 3. 検証の追加
+
+```hcl
+resource "aws_acm_certificate" "validated" {
+  count = var.domain_name != "" ? 1 : 0
+  
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+  
+  lifecycle {
+    precondition {
+      condition     = can(regex("^[a-zA-Z0-9][a-zA-Z0-9-\\.]*[a-zA-Z0-9]$", var.domain_name))
+      error_message = "ドメイン名の形式が不正です。"
+    }
+  }
+}
+```
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+| 問題 | 原因 | 解決方法 |
+|------|------|----------|
+| `index out of range` | countが0の時に`[0]`でアクセス | `try()`関数や条件チェックを使用 |
+| リソースの予期しない再作成 | リスト内の順序変更 | `for_each`の使用を検討 |
+| 依存関係エラー | count値が他のリソースに依存 | `depends_on`の明示的な指定 |
+
+### デバッグ用の出力
+
+```hcl
+output "debug_certificate_count" {
+  value = length(aws_acm_certificate.cert)
+}
+
+output "debug_certificate_indices" {
+  value = range(length(aws_acm_certificate.cert))
+}
+```
+
+## 関連
+- [AWS ACM証明書のTerraform設定ガイド](./2025.08.01.14.31_how_aws_acm_certificate_terraform_configuration_guide.md)
+- [AWS ACM証明書のProvider設定詳解](./2025.08.01.14.38_how_aws_acm_certificate_provider_configuration_details.md)
+- [ACM証明書管理パターン比較](./2025.08.01.13.47_why_acm_certificate_management_patterns_comparison.md)
+- [Terraform公式ドキュメント - countメタ引数](https://developer.hashicorp.com/terraform/language/meta-arguments/count)


### PR DESCRIPTION
## What
daily-tilのストック（2025.08.01作成分）

 - terraform
   - `aws_acm_certificate` リソース
     - 新規作成された証明書か、既存の証明書を参照するかのパターンについて
     - 作成方法、管理方法
     - 設定項目：`provider`について
     - 設定項目：`count`について

## Why
TerraformによるAWSインフラ構築を実務で行うためにAWSのサービスを調査

## How
n/a