### PR TITLE
docs/my-memo/GitHub Markdownではファイル名が表示されたコードブロックが作成できないことについて

### DIFF
--- a/my-memo/2025.08.12.11.37_cant_write_codeblock_with_filename_in_github_markdown.md
+++ b/my-memo/2025.08.12.11.37_cant_write_codeblock_with_filename_in_github_markdown.md
@@ -1,0 +1,27 @@
+## GitHub Markdownではファイル名が表示されたコードブロックが表示されない
+
+### Whats this file
+※フォーマットに合わせて追記
+
+### {{title}}
+公式ドキュメントでファイル名と一緒にコードブロックを作成することができると記載ない。実際にファイル名と一緒に記載できない
+https://docs.github.com/ja/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks
+
+Qiitaのように下記のようにファイル名と一緒にコードブロックを作成しようとしてもファイル名表示されない
+
+````
+``` json:.vscode/setting.json
+{
+    "files.insertFinalNewline": true,
+}
+```
+````
+
+### 表示の確認
+表示確認用
+
+``` json:.vscode/setting.json
+{
+    "files.insertFinalNewline": true,
+}
+```


### PR DESCRIPTION
## What

## Why

## How
